### PR TITLE
Release v0.1.20210824

### DIFF
--- a/deps.edn
+++ b/deps.edn
@@ -20,7 +20,7 @@
  :deps
    {org.clojure/clojure    {:mvn/version "1.10.3"}
     pmonks/discljord-utils {:git/url "https://github.com/pmonks/discljord-utils.git"
-                            :git/sha "8fe7d0aec1c2fa90265df3ea76fca2ea85ee47d1"}}
+                            :git/sha "92e48d38f74f77b0e55c6d15bba42615a9fe707b"}}
  :aliases
    {; clj -M:run -c /path/to/config.edn
     :run

--- a/resources/build-info.edn
+++ b/resources/build-info.edn
@@ -1,6 +1,6 @@
 {
   :repo "https://github.com/pmonks/ctac-bot.git"
-  :sha  "af211814b3314f5f0d48a8b49307f2d3a2ea9fd7"
+  :sha  "1ee9cf8913d97fc0daa93da9078749cd6745f1cd"
   :tag  "v0.1.20210824"
-  :date #inst "2021-08-24T07:20:39Z"
+  :date #inst "2021-08-24T07:26:44Z"
 }


### PR DESCRIPTION
ctac-bot release v0.1.20210824. See commit log for details of what's included in this release.