### PR TITLE
Release v0.1.20210916

### DIFF
--- a/deps.edn
+++ b/deps.edn
@@ -20,7 +20,7 @@
  :deps
    {org.clojure/clojure    {:mvn/version "1.10.3"}
     pmonks/discljord-utils {:git/url "https://github.com/pmonks/discljord-utils.git"
-                            :git/sha "92e48d38f74f77b0e55c6d15bba42615a9fe707b"}}
+                            :git/sha "955fd20665f1d4e3ca8a2fa41114dfe0f68a030d"}}
  :aliases
    {; clj -M:run -c /path/to/config.edn
     :run

--- a/deps.edn
+++ b/deps.edn
@@ -44,7 +44,7 @@
 
     ; clj -M:kondo
     :kondo
-      {:extra-deps {clj-kondo/clj-kondo {:mvn/version "2021.09.14"}}
+      {:extra-deps {clj-kondo/clj-kondo {:mvn/version "2021.09.15"}}
        :main-opts  ["-m" "clj-kondo.main" "--lint" "src" "resources"]}
 
     ; clj -M:eastwood

--- a/deps.edn
+++ b/deps.edn
@@ -44,7 +44,7 @@
 
     ; clj -M:kondo
     :kondo
-      {:extra-deps {clj-kondo/clj-kondo {:mvn/version "2021.08.06"}}
+      {:extra-deps {clj-kondo/clj-kondo {:mvn/version "2021.09.14"}}
        :main-opts  ["-m" "clj-kondo.main" "--lint" "src" "resources"]}
 
     ; clj -M:eastwood

--- a/deps.edn
+++ b/deps.edn
@@ -49,7 +49,7 @@
 
     ; clj -M:eastwood
     :eastwood
-      {:extra-deps {jonase/eastwood {:mvn/version "0.9.7"}}
+      {:extra-deps {jonase/eastwood {:mvn/version "0.9.9"}}
        :main-opts  ["-m" "eastwood.lint" {:source-paths ["src" "resources"]}]}
 
     ; clj -M:outdated

--- a/deps.edn
+++ b/deps.edn
@@ -20,7 +20,7 @@
  :deps
    {org.clojure/clojure    {:mvn/version "1.10.3"}
     pmonks/discljord-utils {:git/url "https://github.com/pmonks/discljord-utils.git"
-                            :git/sha "955fd20665f1d4e3ca8a2fa41114dfe0f68a030d"}}
+                            :git/sha "0f62f84b66285b244669ecdc1029ef9212ae3239"}}
  :aliases
    {; clj -M:run -c /path/to/config.edn
     :run

--- a/deps.edn
+++ b/deps.edn
@@ -20,7 +20,7 @@
  :deps
    {org.clojure/clojure    {:mvn/version "1.10.3"}
     pmonks/discljord-utils {:git/url "https://github.com/pmonks/discljord-utils.git"
-                            :git/sha "0f62f84b66285b244669ecdc1029ef9212ae3239"}}
+                            :git/sha "ba4faa9a9f164eff6bd18ebf7893c7b260d3ba56"}}
  :aliases
    {; clj -M:run -c /path/to/config.edn
     :run
@@ -28,7 +28,7 @@
 
     ; clj -X:uberjar
     :uberjar
-      {:replace-deps {com.github.seancorfield/depstar {:mvn/version "2.1.297"}}
+      {:replace-deps {com.github.seancorfield/depstar {:mvn/version "2.1.303"}}
        :exec-fn      hf.depstar/uberjar
        :exec-args    {:jar        "./target/ctac-bot-standalone.jar"
                       :jar-type   :uber
@@ -54,5 +54,5 @@
 
     ; clj -M:outdated
     :outdated
-      {:extra-deps {com.github.liquidz/antq {:mvn/version "1.0.0"}}
+      {:extra-deps {com.github.liquidz/antq {:mvn/version "1.0.1"}}
        :main-opts  ["-m" "antq.core"]}}}

--- a/deps.edn
+++ b/deps.edn
@@ -28,7 +28,7 @@
 
     ; clj -X:uberjar
     :uberjar
-      {:replace-deps {com.github.seancorfield/depstar {:mvn/version "2.1.278"}}
+      {:replace-deps {com.github.seancorfield/depstar {:mvn/version "2.1.297"}}
        :exec-fn      hf.depstar/uberjar
        :exec-args    {:jar        "./target/ctac-bot-standalone.jar"
                       :jar-type   :uber
@@ -54,5 +54,5 @@
 
     ; clj -M:outdated
     :outdated
-      {:extra-deps {com.github.liquidz/antq {:mvn/version "0.16.3"}}
+      {:extra-deps {com.github.liquidz/antq {:mvn/version "1.0.0"}}
        :main-opts  ["-m" "antq.core"]}}}

--- a/pom.xml
+++ b/pom.xml
@@ -3,7 +3,7 @@
   <modelVersion>4.0.0</modelVersion>
   <groupId>org.clojars.pmonks</groupId>
   <artifactId>ctac-bot</artifactId>
-  <version>0.1.20210824</version>
+  <version>0.1.20210916</version>
   <name>ctac-bot</name>
   <description>A special purpose Discord bot.</description>
   <url>https://github.com/pmonks/ctac-bot</url>

--- a/resources/build-info.edn
+++ b/resources/build-info.edn
@@ -1,6 +1,6 @@
 {
   :repo "https://github.com/pmonks/ctac-bot.git"
-  :sha  "1ee9cf8913d97fc0daa93da9078749cd6745f1cd"
-  :tag  "v0.1.20210824"
-  :date #inst "2021-08-24T07:26:44Z"
+  :sha  "5d6213de28d97fa5f16803c1534a4a5c2fd2343a"
+  :tag  "v0.1.20210916"
+  :date #inst "2021-09-16T20:00:31Z"
 }


### PR DESCRIPTION
ctac-bot release v0.1.20210916. See commit log for details of what's included in this release.