### PR TITLE
Release v1.0.20220123

### DIFF
--- a/resources/build-info.edn
+++ b/resources/build-info.edn
@@ -1,3 +1,4 @@
-{:hash "4c2c0e3b1394bd5b2464e62e23383b2156fbb06c",
- :date #inst "2022-01-23T08:07:56.571-00:00",
+{:hash "cec588cbb020a8b2c464c62f2d8da15f5b902e00",
+ :date #inst "2022-01-23T08:48:42.717-00:00",
+ :repo "https://github.com/pmonks/ctac-bot.git",
  :tag "1.0.20220123"}


### PR DESCRIPTION
org.github.pmonks/ctac-bot release v1.0.20220123. See commit log for details of what's included in this release.