### PR TITLE
Release v1.0.20220221

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -22,7 +22,7 @@ jobs:
         with:
           distribution: 'temurin'
           java-version: 17
-      - uses: DeLaGuardo/setup-clojure@3.7
+      - uses: DeLaGuardo/setup-clojure@4.0
         with:
           tools-deps: latest
       - uses: actions/cache@v2

--- a/README.md
+++ b/README.md
@@ -22,9 +22,9 @@ Please review the [privacy policy](https://github.com/pmonks/ctac-bot/blob/main/
 
 ### Developer Workflow
 
-The `ctac-bot` source repository has two permanent branches: `main` and `dev`.  **All development must occur either in branch `dev`, or (preferably) in feature branches off of `dev`.**  All PRs must also be submitted against `dev`; the `main` branch is **only** updated from `dev` via PRs created by the core development team.  All other changes submitted to `main` will be rejected.
+This project uses the [git-flow branching strategy](https://nvie.com/posts/a-successful-git-branching-model/), with the caveat that the permanent branches are called `main` and `dev`, and any changes to the `main` branch are considered a release and auto-deployed (push to Heroku).
 
-This model allows otherwise unrelated changes to be batched up in the `dev` branch, integration tested there, and then released en masse to the `main` branch.  The `main` branch is configured to auto-deploy to a production environment, and therefore that branch must only contain tested, functioning code.
+For this reason, **all development must occur either in branch `dev`, or (preferably) in temporary branches off of `dev`.**  All PRs from forked repos must also be submitted against `dev`; the `main` branch is **only** updated from `dev` via PRs created by the core development team.  All other changes submitted to `main` will be rejected.
 
 ## License
 

--- a/deps.edn
+++ b/deps.edn
@@ -19,7 +19,7 @@
 {:paths ["src" "resources"]
  :deps
    {org.clojure/clojure               {:mvn/version "1.10.3"}
-    com.github.pmonks/discljord-utils {:mvn/version "1.0.64"}}
+    com.github.pmonks/discljord-utils {:mvn/version "1.0.67"}}
  :aliases
    {:build {:deps       {io.github.seancorfield/build-clj {:git/tag "v0.6.7" :git/sha "22c2d09"}
                          com.github.pmonks/pbr            {:mvn/version "RELEASE"}}

--- a/resources/build-info.edn
+++ b/resources/build-info.edn
@@ -1,4 +1,4 @@
-{:hash "cec588cbb020a8b2c464c62f2d8da15f5b902e00",
- :date #inst "2022-01-23T08:48:42.717-00:00",
+{:hash "8b7fff3f36be8f021fc6300bc0b4542889371f0b",
+ :date #inst "2022-02-22T05:05:48.547-00:00",
  :repo "https://github.com/pmonks/ctac-bot.git",
- :tag "1.0.20220123"}
+ :tag "1.0.20220221"}


### PR DESCRIPTION
org.github.pmonks/ctac-bot release v1.0.20220221. See commit log for details of what's included in this release.